### PR TITLE
added support for option 'collection', which makes this plugin only effect files belonging to a collection, such as the ones created by 'metalsmith-collections'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,20 @@ metalsmith.use(permalinks({
   ---
   ```
 
+  Another way to make metalsmith-permalinks ignore a file is by grouping the files you want metalsmith-permalinks to generate permalinks
+  for into a collection, using `metalsmith-collections`, then tell metalsmith-permalinks to *only* do permalinks for files in that collection:
+
+  E.g.:
+
+  ```js
+var metalsmith = new Metalsmith(__dirname)
+  .use(permalinks({
+    pattern: ':title',
+    collection: 'posts'
+}));
+  ```
+  using a `metalsmith` instance passing the option above will cause `metalsmith-permalinks` to skip any file not in that collection.
+
 #### CLI
 
   You can also use the plugin with the Metalsmith CLI by adding a key to your `metalsmith.json` file:

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,13 +30,26 @@ function plugin(options){
   options = normalize(options);
   var pattern = options.pattern;
   var dupes = {};
+  var collectionName = options.collection;
 
   return function(files, metalsmith, done){
     setImmediate(done);
     Object.keys(files).forEach(function(file){
+      var data = files[file];
+      if (collectionName) {
+        var metadata = metalsmith.metadata();
+        var collection = metadata &&
+                         metadata.collections &&
+                         metadata.collections[collectionName];
+        if (!collection || -1 === collection.indexOf(data)) {
+            // if a `collection` option was passed, but either that collection
+            // doesn't exist, or the current file doesn't belong to that
+            // collection, we skip creating a permalink for it
+            return;
+        }
+      }
       debug('checking file: %s', file);
       if (!html(file)) return;
-      var data = files[file];
       if (data['permalink'] === false) return;
       var path = replace(pattern, data, options) || resolve(file);
       var fam = family(file, files);
@@ -78,6 +91,7 @@ function normalize(options){
   options = options || {};
   options.date = options.date ? format(options.date) : format('YYYY/MM/DD');
   options.relative = options.hasOwnProperty('relative') ? options.relative : true;
+  options.collection = options.collection? options.collection : null;
   return options;
 }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "assert-dir-equal": "0.0.1",
     "metalsmith": "0.x",
+    "metalsmith-collections": "^0.6.0",
     "mocha": "1.x",
     "rimraf": "^2.2.8"
   }

--- a/test/fixtures/collections/src/in_collection.html
+++ b/test/fixtures/collections/src/in_collection.html
@@ -1,0 +1,3 @@
+---
+title: in collection
+---

--- a/test/fixtures/collections/src/not_in_collection.html
+++ b/test/fixtures/collections/src/not_in_collection.html
@@ -1,0 +1,3 @@
+---
+title: not in collection
+---

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var equal = require('assert-dir-equal');
 var Metalsmith = require('metalsmith');
 var permalinks = require('..');
+var collections = require('metalsmith-collections');
 
 describe('metalsmith-permalinks', function(){
   before(function(done){
@@ -134,5 +135,30 @@ describe('metalsmith-permalinks', function(){
         equal('test/fixtures/false-permalink/expected', 'test/fixtures/false-permalink/build');
         done();
       });
+  });
+
+  it('should ignore files not in a collection', function(done){
+    Metalsmith('test/fixtures/collections')
+      .use(collections({
+        posts: {
+          pattern: 'in_collection.html'
+        }
+      }))
+      .use(permalinks({
+          pattern: ':title',
+          collection: 'posts'
+      }))
+      .use(function (files, metalsmith, done) {
+          assert.equal(2, Object.keys(files).length);
+          assert.equal(true, 'not_in_collection.html' in files);
+          assert.equal(true, 'in-collection/index.html' in files);
+          done();
+      })
+      .build(function(err){
+        if (err) return done(err);
+        equal('test/fixtures/pattern/expected', 'test/fixtures/pattern/build');
+        done();
+      });
+
   });
 });


### PR DESCRIPTION
I think this is good alternative to setting "permalink: false" in the front matter for people who want to rely more on `metalsmith-collections`.
