### PR TITLE
LinkSets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 test/fixtures/*/build/
+*.swp

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,11 +4,15 @@ var moment = require('moment');
 var path = require('path');
 var slug = require('slug-component');
 var substitute = require('substitute');
+var utils = require('./utils');
 
 var basename = path.basename;
 var dirname = path.dirname;
 var extname = path.extname;
 var join = path.join;
+
+var find = utils.arrayFind;
+var merge = utils.objectMerge;
 
 /**
  * Expose `plugin`.
@@ -28,21 +32,44 @@ module.exports = plugin;
 
 function plugin(options){
   options = normalize(options);
-  var pattern = options.pattern;
+
+  var linksets          = options.linksets;
+  var defaultLinkset    = find(linksets, function(ls) { return !!ls.isDefault; });
+
+  if (!defaultLinkset) {
+    defaultLinkset = { 
+        pattern : options.pattern,
+        relative: options.relative,
+        date    : options.date
+    };
+  }
+
   var dupes = {};
+
+  function findLinkset(file) {
+    var set = find(linksets, function(ls) { 
+        return Object.keys(ls.match).reduce(function(sofar, key) {
+            return sofar && (file[key] === ls.match[key]);
+        }, true);
+    });
+
+    return set || defaultLinkset;
+  }
 
   return function(files, metalsmith, done){
     setImmediate(done);
     Object.keys(files).forEach(function(file){
-      debug('checking file: %s', file);
-      if (!html(file)) return;
       var data = files[file];
+      debug('checking file: %s', file);
+
+      if (!html(file)) return;
       if (data['permalink'] === false) return;
-      var path = replace(pattern, data, options) || resolve(file);
+
+      var linkset = merge(findLinkset(data), defaultLinkset);
+      var path = replace(linkset.pattern, data, linkset) || resolve(file);
       var fam = family(file, files);
 
-
-      if (options.relative) {
+      if (linkset.relative) {
         // track duplicates for relative files to maintain references
         for (var key in fam) {
           var rel = join(path, key);
@@ -78,6 +105,7 @@ function normalize(options){
   options = options || {};
   options.date = options.date ? format(options.date) : format('YYYY/MM/DD');
   options.relative = options.hasOwnProperty('relative') ? options.relative : true;
+  options.linksets = options.linksets || [];
   return options;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,14 @@ function plugin(options){
   function findLinkset(file) {
     var set = find(linksets, function(ls) { 
         return Object.keys(ls.match).reduce(function(sofar, key) {
-            return sofar && (file[key] === ls.match[key]);
+            if (!sofar) { return sofar; }
+
+            if (file[key] === ls.match[key]) { return true; }
+            if (file[key] && file[key].indexOf) {
+                return file[key].indexOf(ls.match[key]) > -1;
+            }
+
+            return false;
         }, true);
     });
 
@@ -65,7 +72,9 @@ function plugin(options){
       if (!html(file)) return;
       if (data['permalink'] === false) return;
 
-      var linkset = merge(findLinkset(data), defaultLinkset);
+      var linkset = merge({}, findLinkset(data), defaultLinkset);
+      debug('applying pattern: %s to file: %s', linkset.pattern, file);
+
       var path = replace(linkset.pattern, data, linkset) || resolve(file);
       var fam = family(file, files);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,24 @@
+module.exports = {
+  
+  /** polyfill for Array.find in ES6 */
+  arrayFind: function(ary, callback, context) {
+    for (var i = 0; i < ary.length; i++) {
+      if (callback.call(context, ary[i], i, ary)) {
+        return ary[i];
+      }
+    }
+  },
+
+  /** merge keys into destination, overwriting from the right */
+  objectMerge: function(dest, source /* ... */) {
+    for (var i = arguments.length - 1; i > 0; i--) {
+      var arg = arguments[i];
+      Object.keys(arg).forEach(function(key) {
+        dest[key] = arg[key];
+      });
+    }
+
+    return dest;
+  }
+
+}

--- a/test/fixtures/simple-linksets/expected/badfoo/index.html
+++ b/test/fixtures/simple-linksets/expected/badfoo/index.html
@@ -1,0 +1,1 @@
+I should be at /bad-foo

--- a/test/fixtures/simple-linksets/expected/bar/bar/index.html
+++ b/test/fixtures/simple-linksets/expected/bar/bar/index.html
@@ -1,0 +1,1 @@
+i should be at bar/bar

--- a/test/fixtures/simple-linksets/expected/foo/foo/index.html
+++ b/test/fixtures/simple-linksets/expected/foo/foo/index.html
@@ -1,0 +1,1 @@
+i should be at foo/foo

--- a/test/fixtures/simple-linksets/src/badfoo.html
+++ b/test/fixtures/simple-linksets/src/badfoo.html
@@ -1,0 +1,5 @@
+---
+title: Bad Foo
+foo: 10
+---
+I should be at /bad-foo

--- a/test/fixtures/simple-linksets/src/bar.html
+++ b/test/fixtures/simple-linksets/src/bar.html
@@ -1,0 +1,5 @@
+---
+title: Bar
+bar: 21
+---
+i should be at bar/bar

--- a/test/fixtures/simple-linksets/src/foo.html
+++ b/test/fixtures/simple-linksets/src/foo.html
@@ -1,0 +1,5 @@
+---
+title: Foo
+foo: 34
+---
+i should be at foo/foo

--- a/test/index.js
+++ b/test/index.js
@@ -135,4 +135,23 @@ describe('metalsmith-permalinks', function(){
         done();
       });
   });
+
+  it('should match arbitrary metadata', function(done) {
+    Metalsmith('test/fixtures/simple-linksets')
+      .use(permalinks({
+        linksets: [{
+          match: { foo: 34 },
+          pattern: 'foo/:title'
+        },{
+          match: { bar: 21 },
+          pattern: 'bar/:title'
+        }]
+      }))
+      .build(function(err){
+        if (err) return done(err);
+        equal('test/fixtures/simple-linksets/expected', 'test/fixtures/simple-linksets/build');
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
## What?

In my build, I'd like to have different permalink patterns per collection. I'm currently doing it by combining PR #24 with multiple invocations of the plugin, effectively giving me "scoped" permalink patterns. While it's working (for the most part), it's clumsy.

This PR is a proposal for a new feature to introduce scoped sets of options, using the passed in options as default, matching on arbitrary metadata. The idea is that, e.g., a `blogposts` collection could have a permalink pattern like `:date/:title`, while a `pages` collection could have a different pattern, such as `pages/:title`.

Backwards compatibility (meaning the tests pass :icecream:) is maintained by making the original options objects act as defaults for each linkset, and also as the default linkset itself.
## How it would work

``` js
  .use(permalinks({
      // original options would act as the keys of a `default` linkset, 
      pattern: ':title',
      date: 'YYYY',

      // each linkset defines a match, and any other desired option
      linksets: [{
          match: { collection: 'blogposts' },
          pattern: 'blog/:date/:title',
          date: 'mmddyy'
      },{
          match: { collection: 'pages' },
          pattern: 'pages/:title'
      }]
  }));

```

Eventually, I think a bunch of more sophisticated matchers et al. would be awesome, and a bunch more tests, but I wanted to make sure I wasn't running down a path that you'd disagree with too strongly.
