### PR TITLE
allows momentjs injection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ module.exports = plugin;
  *
  * @param {Object} options
  *   @property {String} pattern
- *   @property {String or Function} date
+ *   @property {Function} formatter
  * @return {Function}
  */
 
@@ -76,7 +76,7 @@ function plugin(options){
 function normalize(options){
   if ('string' == typeof options) options = { pattern: options };
   options = options || {};
-  options.date = options.date ? format(options.date) : format('YYYY/MM/DD');
+  options.date = options.formatter || format('YYYY/MM/DD');  
   options.relative = options.hasOwnProperty('relative') ? options.relative : true;
   return options;
 }
@@ -146,11 +146,11 @@ function replace(pattern, data, options){
   if (!pattern) return null;
   var keys = params(pattern);
   var ret = {};
-
+  
   for (var i = 0, key; key = keys[i++];) {
     var val = data[key];
     if (val == null) return null;
-    if (val instanceof Date) {
+    if (options.date(val) != 'Invalid date') {
       ret[key] = options.date(val);
     } else {
       ret[key] = slug(val.toString());


### PR DESCRIPTION
This change replaces the date parameter with a formatter parameter which
allows you to insert a custom formatter function. So you are able to
define the momentjs instance according to your needs. For example it
enables you to define the locale, enable strict mode and specify a date
format matching pattern.

``` javascript
{
  pattern: 'articles/:date/:title',
  formatter: function(date){
    return moment(date, 'DD.MM.YYYY HH:mm', 'de', true).format('DD-MMM-YYYY');
  }
}
```
