### PR TITLE
Fix #25, all falsy pattern values and empty arrays are now treated the same

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,7 @@ function replace(pattern, data, options){
 
   for (var i = 0, key; key = keys[i++];) {
     var val = data[key];
-    if (val == null) return null;
+    if (!val || Array.isArray(val) && val.length === 0) return null;
     if (val instanceof Date) {
       ret[key] = options.date(val);
     } else {

--- a/test/fixtures/empty-array/src/emptyarray.html
+++ b/test/fixtures/empty-array/src/emptyarray.html
@@ -1,0 +1,5 @@
+---
+array: []
+title: test
+---
+test

--- a/test/fixtures/falsy/src/emptystring.html
+++ b/test/fixtures/falsy/src/emptystring.html
@@ -1,0 +1,5 @@
+---
+falsy: ''
+title: test
+---
+test

--- a/test/fixtures/falsy/src/false.html
+++ b/test/fixtures/falsy/src/false.html
@@ -1,0 +1,5 @@
+---
+falsy: false
+title: test
+---
+test

--- a/test/fixtures/falsy/src/nan.html
+++ b/test/fixtures/falsy/src/nan.html
@@ -1,0 +1,5 @@
+---
+falsy: .NAN
+title: test
+---
+test

--- a/test/fixtures/falsy/src/null.html
+++ b/test/fixtures/falsy/src/null.html
@@ -1,0 +1,5 @@
+---
+falsy: null
+title: test
+---
+test

--- a/test/fixtures/falsy/src/undefined.html
+++ b/test/fixtures/falsy/src/undefined.html
@@ -1,0 +1,4 @@
+---
+title: test
+---
+test

--- a/test/index.js
+++ b/test/index.js
@@ -135,4 +135,33 @@ describe('metalsmith-permalinks', function(){
         done();
       });
   });
+
+  it('should use the resolve path for false values (not root)', function (done) {
+    Metalsmith('test/fixtures/falsy')
+      .use(permalinks(':falsy/:title'))
+      .use(function (files, metalsmith, pluginDone) {
+        Object.keys(files).forEach(function (file) {
+         assert.notEqual(files[file].path.charAt(0), '/');
+        });
+        done();
+      })
+      .build(function (err) {
+        if (err) return done(err);
+      });
+  });
+
+
+  it('should use the resolve path for empty arrays (not root)', function (done) {
+    Metalsmith('test/fixtures/empty-array')
+      .use(permalinks(':array/:title'))
+      .use(function (files, metalsmith, pluginDone) {
+        Object.keys(files).forEach(function (file) {
+         assert.notEqual(files[file].path.charAt(0), '/');
+        });
+        done();
+      })
+      .build(function (err) {
+        if (err) return done(err);
+      });
+  });
 });


### PR DESCRIPTION
Some falsy values were getting past the previous check `if(val == null)` which ended up creating some wacky directory structures. And in the case of [issue 25](https://github.com/segmentio/metalsmith-permalinks/issues/25), attempting to write to root (or if running as sudo actually writing to root, which could be quite dangerous).
