### PR TITLE
exposed slug-component options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,8 @@ module.exports = plugin;
  * @param {Object} options
  *   @property {String} pattern
  *   @property {String or Function} date
+ *   @property {String or RegExp} [replace] characters to replace, default: `/[^a-z0-9]/g`
+ *   @property {String} [separator] separator to insert, default: `-`
  * @return {Function}
  */
 
@@ -153,7 +155,7 @@ function replace(pattern, data, options){
     if (val instanceof Date) {
       ret[key] = options.date(val);
     } else {
-      ret[key] = slug(val.toString());
+      ret[key] = slug(val.toString(), options);
     }
   }
 


### PR DESCRIPTION
For now we can use only [a-z0-9] for permalinks. With slug-component exposed options we can use any symbols, for example to use literal permalink:

``` javascript
.use(permalinks({
    relative: false,
    pattern: ':permalink',
    replace: /^\/|\/$/,
    separator: '-',
}))
```

PS.
slug-component is a little bit an odd dependency, just a few lines of code:

``` javascript
module.exports = function (str, options) {
  options || (options = {});
  return str.toLowerCase()
    .replace(options.replace || /[^a-z0-9]/g, ' ')
    .replace(/^ +| +$/g, '')
    .replace(/ +/g, options.separator || '-')
};
```
