### PR TITLE
Adding default value for a placeholder `:PROPERTY'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,22 @@ var metalsmith = new Metalsmith(__dirname)
   }));
 ```
 
-  The `pattern` can contain a reference to any piece of metadata associated with the file by using the `:PROPERTY` syntax for placeholders.
+  The `pattern` can contain a reference to any piece of metadata associated with the file by using the `:PROPERTY` syntax for placeholders:
+
+```js
+---
+title: A simple title
+PROPERTY: special
+---
+```
+
+  also, a default value for `PROPERTY' can be set in the global metadata:
+
+```js
+metalsmith.metadata({
+  PROPERTY: "special"
+});
+```
 
   If no pattern is provided, the files won't be remapped, but the `path` metadata key will still be set, so that you can use it for outputting links to files in the template.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,9 +38,8 @@ function plugin(options){
       if (!html(file)) return;
       var data = files[file];
       if (data['permalink'] === false) return;
-      var path = replace(pattern, data, options) || resolve(file);
+      var path = replace(pattern, data, options, metalsmith._metadata) || resolve(file);
       var fam = family(file, files);
-
 
       if (options.relative) {
         // track duplicates for relative files to maintain references
@@ -142,13 +141,13 @@ function resolve(path){
  * @return {String or Null}
  */
 
-function replace(pattern, data, options){
+function replace(pattern, data, options, metadata){
   if (!pattern) return null;
   var keys = params(pattern);
   var ret = {};
 
   for (var i = 0, key; key = keys[i++];) {
-    var val = data[key];
+    var val = data[key] || metadata[key];
     if (val == null) return null;
     if (val instanceof Date) {
       ret[key] = options.date(val);


### PR DESCRIPTION
Adding a pair value to the global metadata:

``` js
metalsmith.metadata({
  PROPERTY: "special"
});
```

and reading it from the metalsmith-permalinks plugin, so that it's then possible to have default values for a placeholder.

I personally use it to create personalized urls based on the "locale" value.
