### PR TITLE
check type is string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ function plugin(options){
 function normalize(options){
   if ('string' == typeof options) options = { pattern: options };
   options = options || {};
-  options.date = options.date ? format(options.date) : format('YYYY/MM/DD');
+  options.date = typeof options.date === 'string' ? format(options.date) : format('YYYY/MM/DD');
   options.relative = options.hasOwnProperty('relative') ? options.relative : true;
   options.linksets = options.linksets || [];
   return options;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "version": "0.4.0",
   "license": "MIT",
   "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha"
+  },
   "dependencies": {
     "slug-component": "~1.1.0",
     "debug": "~0.7.4",


### PR DESCRIPTION
- Addresses #47
- `options.date` is assigned to a function after the initial build, it throws an error when passed into moment's `format(string)`
