### PR TITLE
Feature/add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 test/fixtures/*/build/
 *.swp
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '4'
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune
+  - npm test
+  - npm run coverage
+  - npm run check-coverage
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 
-# metalsmith-permalinks
+# metalsmith-permalinks [![npm](https://img.shields.io/npm/v/metalsmith-permalinks.svg?style=flat-square)](https://www.npmjs.com/package/metalsmith-permalinks) [![Travis](https://img.shields.io/travis/segmentio/metalsmith-permalinks.svg?style=flat-square)](https://travis-ci.org/segmentio/metalsmith-permalinks)
 
   A Metalsmith plugin that applies a custom permalink pattern to files, and renames them so that they're nested properly for static sites (converting `about.html` into `about/index.html`).
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "metalsmith-permalinks",
   "description": "A metalsmith plugin for permalinks.",
   "version": "0.0.0-semantic-release",
+  "repository": "git://github.com/segmentio/metalsmith-permalinks.git",
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "metalsmith-permalinks",
   "description": "A metalsmith plugin for permalinks.",
   "version": "0.0.0-semantic-release",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/cameronjroe/metalsmith-permalinks.git"
-  },
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "metalsmith-permalinks",
   "description": "A metalsmith plugin for permalinks.",
-  "repository": "git://github.com/segmentio/metalsmith-permalinks.git",
-  "version": "0.4.0",
+  "version": "0.0.0-semantic-release",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cameronjroe/metalsmith-permalinks.git"
+  },
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "coverage": "istanbul cover _mocha",
+    "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {
     "slug-component": "~1.1.0",
@@ -16,8 +22,10 @@
   },
   "devDependencies": {
     "assert-dir-equal": "0.0.1",
+    "istanbul": "0.4.2",
     "metalsmith": "0.x",
     "mocha": "1.x",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.2.8",
+    "semantic-release": "^4.3.5"
   }
 }


### PR DESCRIPTION
Even though this is a small plugin, it's a pretty useful one so I thought I'd add coverage and prep a travis build for people to make sure they're on the latest release. You'll just need to confirm that travis works and set up [semantic-release-cli](https://github.com/semantic-release/cli) if you're cool adding it.
- [ ] confirm build works on travis
- [ ] set up semantic-release-cli for continuous npm releases
