### PR TITLE
Fix 'TypeError: options.date is not a function'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,12 @@ function normalize(options){
   options.date = typeof options.date === 'string' ? format(options.date) : format('YYYY/MM/DD');
   options.relative = options.hasOwnProperty('relative') ? options.relative : true;
   options.linksets = options.linksets || [];
+  options.linksets = options.linksets.map(function(linkset) {
+    if (linkset.date && typeof(linkset.date === 'string'))
+      linkset.date = format(linkset.date);
+
+    return(linkset);
+  });
   return options;
 }
 


### PR DESCRIPTION
when using string date on linksets.
