### PR TITLE
Fix segmentio/metalsmith-permalinks#48, a patch to normalize() linksets.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,12 @@ function normalize(options){
   options.date = typeof options.date === 'string' ? format(options.date) : format('YYYY/MM/DD');
   options.relative = options.hasOwnProperty('relative') ? options.relative : true;
   options.linksets = options.linksets || [];
+  
+  for (var i = 0, linkset; linkset = options.linksets[i++];) {
+    linkset.date = typeof linkset.date === 'string' ? format(linkset.date) : format('YYYY/MM/DD');
+    linkset.relative = linkset.hasOwnProperty('relative') ? linkset.relative : true;
+  }
+  
   return options;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,7 @@ function replace(pattern, data, options){
   for (var i = 0, key; key = keys[i++];) {
     var val = data[key];
     if (val == null) return null;
-    if (val instanceof Date) {
+    if (val instanceof Date || moment.isMoment(val)) {
       ret[key] = options.date(val);
     } else {
       ret[key] = slug(val.toString());


### PR DESCRIPTION
`normalize()` doesn't process linksets; it ensures that `options.linksets` exists, but doesn't apply date formatting or a default value for the `relative` option, as it does for basic options. This is a simple patch to ensure linksets get the same treatment.
