### PR TITLE
html check function: corrected regex

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -220,5 +220,5 @@ function params(pattern){
  */
 
 function html(path){
-  return /.html/.test(extname(path));
+  return /\.html/.test(extname(path));
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,5 +220,5 @@ function params(pattern){
  */
 
 function html(path){
-  return /\.html/.test(extname(path));
+  return '.html' === extname(path);
 }


### PR DESCRIPTION
Tests for `.html` rather than `{any char}html` now.
