### PR TITLE
Add option to override a page's permalink

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,6 +104,20 @@ metalsmith.use(permalinks({
   ---
   ```
 
+#### Overriding the permalink for a file
+
+  Using the `permalink` property in a file's front-matter, its permalink can be overridden. This can be useful for transferring
+  projects over to Metalsmith where pages don't follow a strict permalink system.
+
+  For example, in one of your pages:
+
+```js
+---
+title: My Post
+permalink: "posts/my-post"
+---
+```
+
 #### CLI
 
   You can also use the plugin with the Metalsmith CLI by adding a key to your `metalsmith.json` file:

--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,10 @@ function plugin(options){
 
       var path = replace(linkset.pattern, data, linkset) || resolve(file);
       var fam = family(file, files);
+      
+      if(data.hasOwnProperty('permalink')) {
+        path = data['permalink'];
+      }
 
       if (linkset.relative) {
         // track duplicates for relative files to maintain references


### PR DESCRIPTION
Using the property `permalink` in a file's front-matter, its permalink can be overridden. I find this especially useful for transferring old WordPress posts over to my Metalsmith project because I can just set the permalink (including subdirectories) on a per-page basis.