### PR TITLE
Create support for dot notated patterns

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,7 +185,12 @@ function replace(pattern, data, options){
   var ret = {};
 
   for (var i = 0, key; key = keys[i++];) {
-    var val = data[key];
+    var val = '';
+    if(key.indexOf('.') > -1) {
+      val = deref(data, key);
+    } else {
+      val = data[key];
+    }
     if (val == null) return null;
     if (val instanceof Date) {
       ret[key] = options.date(val);
@@ -197,6 +202,13 @@ function replace(pattern, data, options){
   return substitute(pattern, ret);
 }
 
+function deref(obj, s) {
+  var i = 0;
+  s = s.split('.');
+  while (obj && i < s.length)
+    obj = obj[s[i++]];
+}
+
 /**
  * Get the params from a `pattern` string.
  *
@@ -205,10 +217,10 @@ function replace(pattern, data, options){
  */
 
 function params(pattern){
-  var matcher = /:(\w+)/g;
+  var matcher = /:(\w)+(.\w+)?/g;
   var ret = [];
   var m;
-  while (m = matcher.exec(pattern)) ret.push(m[1]);
+  while (m = matcher.exec(pattern)) ret.push(m[0]);
   return ret;
 }
 

--- a/test/fixtures/pattern/src/one.html
+++ b/test/fixtures/pattern/src/one.html
@@ -1,5 +1,7 @@
 ---
 title: One Post
+series:
+    name: A Test
 ---
 
 one

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,17 @@ describe('metalsmith-permalinks', function(){
 
   });
 
+  it('should replace a dot noteated pattern', function(done){
+    Metalsmith('test/fixtures/pattern')
+      .use(permalinks({ pattern: ':series.name' }))
+      .build(function(err){
+        if (err) return done(err);
+        equal('test/fixtures/pattern/expected', 'test/fixtures/pattern/build');
+        done();
+      });
+
+  });
+
   it('should accepts a shorthand string', function(done){
     Metalsmith('test/fixtures/shorthand')
       .use(permalinks(':title'))


### PR DESCRIPTION
This will add support for dot notated patterns such as ```:site.name``` and ```author.name```