### PR TITLE
Slug replaced with actively developed slugify: Fixes #82

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,55 +1,84 @@
+1.0.0 - September 6, 2018
 
-0.4.0 - September 2, 2014
--------------------------
-* add `permalink: false` option to disable permalinking
+- Published latest version and fixed API by releasing v1
 
-0.3.2 - June 11, 2014
----------------------
-* fix installing `substitute` dependency
+  0.4.0 - September 2, 2014
 
-0.3.1 - June 2, 2014
---------------------
-* fix backslashes in permalinks on windows
-* cleanup tests
+---
 
-0.3.0 - April 2, 2014
----------------------
-* fix relative file copying
-* add option to turn off relative file copying
+- add `permalink: false` option to disable permalinking
 
-0.2.2 - March 14, 2014
-----------------------
-* remove `debugger` statement, holy crap
+  0.3.2 - June 11, 2014
 
-0.2.1 - March 14, 2014
-----------------------
-* remove `debugger` statement
+---
 
-0.2.0 - March 11, 2014
-----------------------
-* add `date` option for rendering dates
+- fix installing `substitute` dependency
 
-0.1.3 - March 11, 2014
-----------------------
-* `toString` replacements
+  0.3.1 - June 2, 2014
 
-0.1.2 - March 10, 2014
-----------------------
-* remove `debugger` statement
+---
 
-0.1.1 - March 7, 2014
----------------------
-* fix `substitute` dependency
+- fix backslashes in permalinks on windows
+- cleanup tests
 
-0.1.0 - March 6, 2014
----------------------
-* add string shorthand
-* add duplicating of relative assets
+  0.3.0 - April 2, 2014
 
-0.0.2 - February 6, 2014
-------------------------
-* add debug statements
+---
 
-0.0.1 - February 6, 2014
-------------------------
+- fix relative file copying
+- add option to turn off relative file copying
+
+  0.2.2 - March 14, 2014
+
+---
+
+- remove `debugger` statement, holy crap
+
+  0.2.1 - March 14, 2014
+
+---
+
+- remove `debugger` statement
+
+  0.2.0 - March 11, 2014
+
+---
+
+- add `date` option for rendering dates
+
+  0.1.3 - March 11, 2014
+
+---
+
+- `toString` replacements
+
+  0.1.2 - March 10, 2014
+
+---
+
+- remove `debugger` statement
+
+  0.1.1 - March 7, 2014
+
+---
+
+- fix `substitute` dependency
+
+  0.1.0 - March 6, 2014
+
+---
+
+- add string shorthand
+- add duplicating of relative assets
+
+  0.0.2 - February 6, 2014
+
+---
+
+- add debug statements
+
+  0.0.1 - February 6, 2014
+
+---
+
 :sparkles:

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 
 [![Build Status][travis-badge]][travis-url]
 
-  A Metalsmith plugin that applies a custom permalink pattern to files, and renames them so that they're nested properly for static sites (converting `about.html` into `about/index.html`).
+A Metalsmith plugin that applies a custom permalink pattern to files, and renames them so that they're nested properly for static sites (converting `about.html` into `about/index.html`).
 
 ## Installation
 
@@ -18,79 +18,88 @@
 var Metalsmith = require('metalsmith');
 var permalinks = require('metalsmith-permalinks');
 
-var metalsmith = new Metalsmith(__dirname)
-  .use(permalinks({
+var metalsmith = new Metalsmith(__dirname).use(
+  permalinks({
     pattern: ':title'
-  }));
+  })
+);
 ```
 
-  The `pattern` can contain a reference to any piece of metadata associated with the file by using the `:PROPERTY` syntax for placeholders.
+The `pattern` can contain a reference to any piece of metadata associated with the file by using the `:PROPERTY` syntax for placeholders.
 
-  If no pattern is provided, the files won't be remapped, but the `path` metadata key will still be set, so that you can use it for outputting links to files in the template.
+If no pattern is provided, the files won't be remapped, but the `path` metadata key will still be set, so that you can use it for outputting links to files in the template.
 
-  The `pattern` can also be a set as such:
+The `pattern` can also be a set as such:
 
 ```js
 var Metalsmith = require('metalsmith');
 var permalinks = require('metalsmith-permalinks');
 
-var metalsmith = new Metalsmith(__dirname)
-  .use(permalinks({
-      // original options would act as the keys of a `default` linkset, 
-      pattern: ':title',
-      date: 'YYYY',
+var metalsmith = new Metalsmith(__dirname).use(
+  permalinks({
+    // original options would act as the keys of a `default` linkset,
+    pattern: ':title',
+    date: 'YYYY',
 
-      // each linkset defines a match, and any other desired option
-      linksets: [{
-          match: { collection: 'blogposts' },
-          pattern: 'blog/:date/:title',
-          date: 'mmddyy'
-      },{
-          match: { collection: 'pages' },
-          pattern: 'pages/:title'
-      }]
-  }));
+    // each linkset defines a match, and any other desired option
+    linksets: [
+      {
+        match: { collection: 'blogposts' },
+        pattern: 'blog/:date/:title',
+        date: 'mmddyy'
+      },
+      {
+        match: { collection: 'pages' },
+        pattern: 'pages/:title'
+      }
+    ]
+  })
+);
 ```
 
 #### Dates
 
-  By default any date will be converted to a `YYYY/MM/DD` format when using in a permalink pattern, but you can change the conversion by passing a `date` option:
+By default any date will be converted to a `YYYY/MM/DD` format when using in a permalink pattern, but you can change the conversion by passing a `date` option:
 
 ```js
-metalsmith.use(permalinks({
-  pattern: ':date/:title',
-  date: 'YYYY'
-}));
+metalsmith.use(
+  permalinks({
+    pattern: ':date/:title',
+    date: 'YYYY'
+  })
+);
 ```
 
-  It uses [moment.js](http://momentjs.com/docs/#/displaying/format/) to format the string.
+It uses [moment.js](http://momentjs.com/docs/#/displaying/format/) to format the string.
 
 #### Custom 'slug' function
-  
-  If you do not like filenames, you can replace slug function.
-  For now only js version of syntax is supported and tested.
+
+If you do not like filenames, you can replace slug function.
+For now only js version of syntax is supported and tested.
 
 ```js
-
-metalsmith.use(permalinks({
- pattern:':title',
- slug: require('transliteration').slugify
-}))
+metalsmith.use(
+  permalinks({
+    pattern: ':title',
+    slug: require('transliteration').slugify
+  })
+);
 ```
-  There are plenty on npm for transliteration and slugs. <https://www.npmjs.com/browse/keyword/transliteration>, better than default slug-component.
+
+There are plenty on npm for transliteration and slugs. <https://www.npmjs.com/browse/keyword/transliteration>, better than default slug-component.
 
 #### Relative Files
 
-  When this plugin rewrites your files to be permalinked properly, it will also duplicate sibling files so that relative links like `/images/cat.gif` will be preserved nicely. You can turn this feature off by setting the `relative` option to `false`.
+When this plugin rewrites your files to be permalinked properly, it will also duplicate sibling files so that relative links like `/images/cat.gif` will be preserved nicely. You can turn this feature off by setting the `relative` option to `false`.
 
-  For example for this source directory:
+For example for this source directory:
 
     src/
       css/
         style.css
       post.html
 
-  Here's what the build directory would look like with `relative` on:
+Here's what the build directory would look like with `relative` on:
 
     build/
       post/
@@ -100,65 +109,69 @@ metalsmith.use(permalinks({
       css/
         style.css
 
-  And here's with `relative` off:
+And here's with `relative` off:
 
     build/
       post/
         index.html
       css/
         style.css
-        
-  `relative` can also be set to `folder`, which uses a strategy that considers files in folder as siblings if the folder is named after the html file.
-  
-  For example using the `folder` strategy with this source directory:
-  
+
+
+`relative` can also be set to `folder`, which uses a strategy that considers files in folder as siblings if the folder is named after the html file.
+
+For example using the `folder` strategy with this source directory:
+
     src/
       post.html
       post/
         image.jpg
-        
-  Here's what the build directory would look like with `relative` set to `folder`:
-  
+
+
+Here's what the build directory would look like with `relative` set to `folder`:
+
     build/
         index.html
         image.jpg
 
 #### Skipping Permalinks for a file
 
-  A file can be ignored by the metalsmith-permalinks plugin if you pass the `permalink: false` option to the yaml metadata of a file.
-  This is useful for hosting a static site on AWS S3, where there is a top level `error.html` file and not an `error/index.html` file.
+A file can be ignored by the metalsmith-permalinks plugin if you pass the `permalink: false` option to the yaml metadata of a file.
+This is useful for hosting a static site on AWS S3, where there is a top level `error.html` file and not an `error/index.html` file.
 
-  For example, in your error.md file:
+For example, in your error.md file:
 
-  ```js
-  ---
-  template: error.html
-  title: error
-  permalink: false
-  ---
-  ```
+```js
+---
+template: error.html
+title: error
+permalink: false
+---
+```
 
 #### Slug Options
 
-[slug](https://www.npmjs.com/package/slug) is used for slugifying strings and it's set to RFC3986 mode by default.
+[slug](https://www.npmjs.com/package/slugify) is used for slugifying strings and it's set to lower-case mode by default.
 
-You can pass custom [slug options](https://www.npmjs.com/package/slug#options):
+You can pass custom [slug options](https://www.npmjs.com/package/slugify#options):
 
 ```js
-metalsmith.use(permalinks({
-  slug: {
-    mode: 'pretty',
-    lower: true
-  }
-}));
+metalsmith.use(
+  permalinks({
+    slug: {
+      replacement: '_',
+      lower: false
+    }
+  })
+);
 ```
 
 #### Overriding the permalink for a file
 
-  Using the `permalink` property in a file's front-matter, its permalink can be overridden. This can be useful for transferring
-  projects over to Metalsmith where pages don't follow a strict permalink system.
+Using the `permalink` property in a file's front-matter, its permalink can be overridden. This can be useful for transferring
+projects over to Metalsmith where pages don't follow a strict permalink system.
 
-  For example, in one of your pages:
+For example, in one of your pages:
 
 ```js
 ---
@@ -169,7 +182,7 @@ permalink: "posts/my-post"
 
 #### CLI
 
-  You can also use the plugin with the Metalsmith CLI by adding a key to your `metalsmith.json` file:
+You can also use the plugin with the Metalsmith CLI by adding a key to your `metalsmith.json` file:
 
 ```json
 {
@@ -183,7 +196,7 @@ permalink: "posts/my-post"
 
 ## License
 
-  MIT
+MIT
 
 [npm-badge]: https://img.shields.io/npm/v/metalsmith-permalinks.svg
 [npm-url]: https://www.npmjs.com/package/metalsmith-permalinks
@@ -191,6 +204,5 @@ permalink: "posts/my-post"
 [travis-url]: https://travis-ci.org/segmentio/metalsmith-permalinks
 [prettier-badge]: https://img.shields.io/badge/code_style-prettier-ff69b4.svg
 [prettier-url]: https://github.com/prettier/prettier
-
 [metalsmith-badge]: https://img.shields.io/badge/metalsmith-plugin-green.svg?longCache=true
 [metalsmith-url]: http://metalsmith.io

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,134 +1,45 @@
-var debug = require('debug')('metalsmith-permalinks');
-var moment = require('moment');
-var path = require('path');
-var slug = require('slug');
-var substitute = require('substitute');
-var utils = require('./utils');
+const debug = require('debug')('metalsmith-permalinks');
+const moment = require('moment');
+const path = require('path');
+const slugify = require('slugify');
+const substitute = require('substitute');
+const utils = require('./utils');
 
-var basename = path.basename;
-var dirname = path.dirname;
-var extname = path.extname;
-var join = path.join;
+const basename = path.basename;
+const dirname = path.dirname;
+const extname = path.extname;
+const join = path.join;
 
-var find = utils.arrayFind;
-var merge = utils.objectMerge;
-
-/**
- * Expose `plugin`.
- */
-module.exports = plugin;
+const find = utils.arrayFind;
+const merge = utils.objectMerge;
 
 /**
- * Metalsmith plugin that renames files so that they're permalinked properly
- * for a static site, aka that `about.html` becomes `about/index.html`.
+ * Maps the slugify function to slug to maintain compatability
  *
+ * @param  {String} text
  * @param  {Object} options
- *   @property {String} pattern
- *   @property {String/Function} date
  *
- * @return {Function}
+ * @return {String}
  */
-function plugin(options) {
-  options = normalize(options);
+const slug = (text, options = {}) =>
+  slugify(text, Object.assign({}, { lower: true }, options));
 
-  var linksets = options.linksets;
-  var defaultLinkset = find(linksets, function(ls) {
-    return !!ls.isDefault;
-  });
-
-  if (!defaultLinkset) {
-    defaultLinkset = {
-      pattern: options.pattern,
-      relative: options.relative,
-      date: options.date,
-      slug: options.slug || { mode: 'rfc3986' }
-    };
-  }
-
-  var dupes = {};
-
-  function findLinkset(file) {
-    var set = find(linksets, function(ls) {
-      return Object.keys(ls.match).reduce(function(sofar, key) {
-        if (!sofar) {
-          return sofar;
-        }
-
-        if (file[key] === ls.match[key]) {
-          return true;
-        }
-        if (file[key] && file[key].indexOf) {
-          return file[key].indexOf(ls.match[key]) > -1;
-        }
-
-        return false;
-      }, true);
-    });
-
-    return set || defaultLinkset;
-  }
-
-  return function(files, metalsmith, done) {
-    setImmediate(done);
-    Object.keys(files).forEach(function(file) {
-      var data = files[file];
-      debug('checking file: %s', file);
-
-      if (!html(file)) return;
-      if (data['permalink'] === false) return;
-
-      var linkset = merge({}, findLinkset(data), defaultLinkset);
-      debug('applying pattern: %s to file: %s', linkset.pattern, file);
-
-      var path = replace(linkset.pattern, data, linkset) || resolve(file);
-
-      var fam;
-      switch (linkset.relative) {
-        case true:
-          fam = family(file, files);
-          break;
-        case 'folder':
-          fam = folder(file, files);
-          break;
-      }
-
-      // track duplicates for relative files to maintain references
-      var moved = {};
-      if (fam) {
-        for (var key in fam) {
-          var rel = join(path, key);
-          dupes[rel] = fam[key];
-          moved[key] = rel;
-        }
-      }
-
-      // add to path data for use in links in templates
-      data.path = '.' == path ? '' : path;
-
-      var out = join(path, options.indexFile || 'index.html');
-
-      relink(data, moved);
-
-      delete files[file];
-      files[out] = data;
-    });
-
-    // add duplicates for relative files after processing to avoid double-dipping
-    // note: `dupes` will be empty if `options.relative` is false
-    Object.keys(dupes).forEach(function(dupe) {
-      files[dupe] = dupes[dupe];
-    });
-  };
-}
-
-function relink(data, moved) {
-  var content = data.contents.toString();
-  Object.keys(moved).forEach(function(to) {
-    var from = moved[to];
+/**
+ * Re-links content
+ *
+ * @param  {Object} data
+ * @param  {Object} moved
+ *
+ * @return {Void}
+ */
+const relink = (data, moved) => {
+  let content = data.contents.toString();
+  Object.keys(moved).forEach(to => {
+    const from = moved[to];
     content = content.replace(from, to);
   });
-  data.contents = new Buffer(content);
-}
+  data.contents = Buffer.from(content);
+};
 
 /**
  * Normalize an options argument.
@@ -137,8 +48,10 @@ function relink(data, moved) {
  *
  * @return {Object}
  */
-function normalize(options) {
-  if ('string' == typeof options) options = { pattern: options };
+const normalize = options => {
+  if ('string' == typeof options) {
+    options = { pattern: options };
+  }
   options = options || {};
   options.date =
     typeof options.date === 'string'
@@ -148,9 +61,8 @@ function normalize(options) {
     ? options.relative
     : true;
   options.linksets = options.linksets || [];
-  options.slug = options.slug || { mode: 'rfc3986' };
   return options;
-}
+};
 
 /**
  * Return a formatter for a given moment.js format `string`.
@@ -158,14 +70,10 @@ function normalize(options) {
  * @param {String} string
  * @return {Function}
  */
-
-function format(string) {
-  return function(date) {
-    return moment(date)
-      .utc()
-      .format(string);
-  };
-}
+const format = string => date =>
+  moment(date)
+    .utc()
+    .format(string);
 
 /**
  * Get a list of sibling and children files for a given `file` in `files`.
@@ -174,23 +82,24 @@ function format(string) {
  * @param {Object} files
  * @return {Object}
  */
+const family = (file, files) => {
+  const ret = {};
+  let dir = dirname(file);
 
-function family(file, files) {
-  var dir = dirname(file);
-  var ret = {};
+  if ('.' == dir) {
+    dir = '';
+  }
 
-  if ('.' == dir) dir = '';
-
-  for (var key in files) {
+  for (const key in files) {
     if (key == file) continue;
     if (key.indexOf(dir) != 0) continue;
     if (html(key)) continue;
-    var rel = key.slice(dir.length);
+    const rel = key.slice(dir.length);
     ret[rel] = files[key];
   }
 
   return ret;
-}
+};
 
 /**
  * Get a list of files that exists in a folder named after `file` for a given `file` in `files`.
@@ -199,25 +108,27 @@ function family(file, files) {
  * @param {Object} files
  * @return {Object}
  */
-function folder(file, files) {
-  var dir = dirname(file);
-  var bn = basename(file, extname(file));
-  var family = {};
+const folder = (file, files) => {
+  const bn = basename(file, extname(file));
+  const family = {};
+  let dir = dirname(file);
 
-  if ('.' === dir) dir = '';
+  if ('.' === dir) {
+    dir = '';
+  }
 
-  var sharedPath = join(dir, bn, '/');
+  const sharedPath = join(dir, bn, '/');
 
-  for (var otherFile in files) {
+  for (const otherFile in files) {
     if (otherFile === file) continue;
     if (otherFile.indexOf(sharedPath) !== 0) continue;
     if (html(otherFile)) continue;
-    var remainder = otherFile.slice(sharedPath.length);
+    const remainder = otherFile.slice(sharedPath.length);
     family[remainder] = files[otherFile];
   }
 
   return family;
-}
+};
 
 /**
  * Resolve a permalink path string from an existing file `path`.
@@ -225,13 +136,15 @@ function folder(file, files) {
  * @param {String} path
  * @return {String}
  */
+const resolve = path => {
+  const base = basename(path, extname(path));
+  let ret = dirname(path);
 
-function resolve(path) {
-  var ret = dirname(path);
-  var base = basename(path, extname(path));
-  if (base != 'index') ret = join(ret, base).replace('\\', '/');
+  if (base != 'index') {
+    ret = join(ret, base).replace('\\', '/');
+  }
   return ret;
-}
+};
 
 /**
  * Replace a `pattern` with a file's `data`.
@@ -239,16 +152,16 @@ function resolve(path) {
  * @param {String} pattern (optional)
  * @param {Object} data
  * @param {Object} options
- * @return {String or Null}
+ *
+ * @return {Mixed} String or Null
  */
-
-function replace(pattern, data, options) {
+const replace = (pattern, data, options) => {
   if (!pattern) return null;
-  var keys = params(pattern);
-  var ret = {};
+  const keys = params(pattern);
+  const ret = {};
 
   for (var i = 0, key; (key = keys[i++]); ) {
-    var val = data[key];
+    const val = data[key];
     if (!val || (Array.isArray(val) && val.length === 0)) return null;
     if (val instanceof Date) {
       ret[key] = options.date(val);
@@ -261,7 +174,7 @@ function replace(pattern, data, options) {
   }
 
   return substitute(pattern, ret);
-}
+};
 
 /**
  * Get the params from a `pattern` string.
@@ -269,13 +182,13 @@ function replace(pattern, data, options) {
  * @param {String} pattern
  * @return {Array}
  */
-function params(pattern) {
-  var matcher = /:(\w+)/g;
-  var ret = [];
-  var m;
+const params = pattern => {
+  const matcher = /:(\w+)/g;
+  const ret = [];
+  let m;
   while ((m = matcher.exec(pattern))) ret.push(m[1]);
   return ret;
-}
+};
 
 /**
  * Check whether a file is an HTML file.
@@ -283,7 +196,105 @@ function params(pattern) {
  * @param {String} path
  * @return {Boolean}
  */
+const html = path => '.html' === extname(path);
 
-function html(path) {
-  return '.html' === extname(path);
-}
+/**
+ * Metalsmith plugin that renames files so that they're permalinked properly
+ * for a static site, aka that `about.html` becomes `about/index.html`.
+ *
+ * @param  {Object} options
+ *   @property {String} pattern
+ *   @property {String/Function} date
+ *
+ * @return {Function}
+ */
+const plugin = options => {
+  options = normalize(options);
+
+  const linksets = options.linksets;
+  let defaultLinkset = find(linksets, function(ls) {
+    return !!ls.isDefault;
+  });
+
+  if (!defaultLinkset) {
+    defaultLinkset = options;
+  }
+
+  const dupes = {};
+
+  const findLinkset = file => {
+    const set = find(linksets, ls =>
+      Object.keys(ls.match).reduce((sofar, key) => {
+        if (!sofar) {
+          return sofar;
+        }
+
+        if (file[key] === ls.match[key]) {
+          return true;
+        }
+        if (file[key] && file[key].indexOf) {
+          return file[key].indexOf(ls.match[key]) > -1;
+        }
+
+        return false;
+      }, true)
+    );
+
+    return set || defaultLinkset;
+  };
+
+  return (files, metalsmith, done) => {
+    setImmediate(done);
+    Object.keys(files).forEach(file => {
+      const data = files[file];
+      debug('checking file: %s', file);
+
+      if (!html(file)) return;
+      if (data['permalink'] === false) return;
+
+      const linkset = merge({}, findLinkset(data), defaultLinkset);
+      debug('applying pattern: %s to file: %s', linkset.pattern, file);
+
+      const path = replace(linkset.pattern, data, linkset) || resolve(file);
+
+      let fam;
+      switch (linkset.relative) {
+        case true:
+          fam = family(file, files);
+          break;
+        case 'folder':
+          fam = folder(file, files);
+          break;
+      }
+
+      // track duplicates for relative files to maintain references
+      const moved = {};
+      if (fam) {
+        for (const key in fam) {
+          const rel = join(path, key);
+          dupes[rel] = fam[key];
+          moved[key] = rel;
+        }
+      }
+
+      // add to path data for use in links in templates
+      data.path = '.' == path ? '' : path;
+
+      const out = join(path, options.indexFile || 'index.html');
+
+      relink(data, moved);
+
+      delete files[file];
+      files[out] = data;
+    });
+
+    // add duplicates for relative files after processing to avoid double-dipping
+    // note: `dupes` will be empty if `options.relative` is false
+    Object.keys(dupes).forEach(dupe => {
+      files[dupe] = dupes[dupe];
+    });
+  };
+};
+
+// Expose `plugin`
+module.exports = plugin;

--- a/package.json
+++ b/package.json
@@ -14,21 +14,21 @@
     "postversion": "git push && git push --tags && npm publish"
   },
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.1.0",
     "moment": "^2.5.1",
-    "slug": "^0.9.1",
+    "slugify": "^1.3.1",
     "substitute": "https://github.com/segmentio/substitute/archive/0.1.0.tar.gz"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.1.0",
-    "eslint": "^5.1.0",
-    "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-prettier": "^2.6.2",
+    "eslint": "^5.7.0",
+    "eslint-config-prettier": "^3.1.0",
+    "eslint-plugin-prettier": "^3.0.0",
     "metalsmith": "^2.3.0",
     "mocha": "^5.2.0",
-    "nodemon": "^1.18.3",
-    "prettier": "^1.13.7",
+    "nodemon": "^1.18.4",
+    "prettier": "^1.14.3",
     "rimraf": "^2.4.1",
-    "transliteration": "^1.6.5"
+    "transliteration": "^1.6.6"
   }
 }

--- a/test/fixtures/slug-custom/src/test.html
+++ b/test/fixtures/slug-custom/src/test.html
@@ -1,3 +1,3 @@
 ---
-title: žaba ťava vôl 1.2.3 = -
+title: žabA ťava vôl 1.2.3 = -
 ---

--- a/test/index.js
+++ b/test/index.js
@@ -217,7 +217,7 @@ describe('metalsmith-permalinks', function() {
       .use(
         permalinks({
           pattern: ':title',
-          slug: { mode: 'pretty', lower: true }
+          slug: { remove: /[*+~.()'"!:@=]+/g, lower: true }
         })
       )
       .build(function(err) {


### PR DESCRIPTION
### What has changed?

Replaced `slug` with `slugify` - the latter is actively maintained and doesn't have security issues.

### Level of change
- API change
- Updated documentation

**Version bump and history required**
