### PR TITLE
Move segment-boneyard/substitute to the repo.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@
 /assets/*
 /temp*
 /repositories/*
+/lib/substitute.js

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const debug = require('debug')('metalsmith-permalinks');
 const moment = require('moment');
 const slugify = require('slugify');
-const substitute = require('substitute');
+const substitute = require('./substitute');
 
 const error = debug.extend('error');
 

--- a/lib/substitute.js
+++ b/lib/substitute.js
@@ -1,0 +1,36 @@
+
+/**
+ * Expose `substitute`
+ */
+
+module.exports = substitute;
+
+/**
+ * Type.
+ */
+
+var type = Object.prototype.toString;
+
+/**
+ * Substitute `:prop` with the given `obj` in `str`
+ *
+ * @param {String} str
+ * @param {Object or Array} obj
+ * @param {RegExp} expr
+ * @return {String}
+ * @api public
+ */
+
+function substitute(str, obj, expr){
+  if (!obj) throw new TypeError('expected an object');
+  expr = expr || /:(\w+)/g;
+  return str.replace(expr, function(_, prop){
+    switch (type.call(obj)) {
+      case '[object Object]':
+        return null != obj[prop] ? obj[prop] : _;
+      case '[object Array]':
+        var val = obj.shift();
+        return null != val ? val : _;
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "moment": "^2.24.0",
-    "slugify": "^1.3.5",
-    "substitute": "https://github.com/segment-boneyard/substitute/archive/0.1.0.tar.gz"
+    "slugify": "^1.3.5"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.1.0",


### PR DESCRIPTION
The package isn't published on npm, and it's small anyway.

Closes #109 

If anyone could get the package published, we could drop this patch.