### PR TITLE
fix: accept simple quotes in permalinks as even Windows accepts it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ const dupeHandlers = {
 
 // These are the invalid path chars on Windows, on *nix systems all are valid except forward slash.
 // However, it is highly unlikely that anyone would want these to appear in a file path and they can still be overridden if necessary
-const invalidPathChars = '[<>:"\'|?*]'
+const invalidPathChars = '[<>:"|?*]'
 const defaultSlugifyRemoveChars = '[^\\w\\s$_+~.()!\\-@\\/]+'
 const emptyStr = ''
 const dash = '-'


### PR DESCRIPTION
### What has changed?

Make sure it's possible to have a permalink with simple quotes (`'`). Even Windows is fine with it :grin: 

Long story short: I'm upgrading `@metasmith/permalinks` to 3.0.0 and with a bit of configuration everything works fine except a permalink with a `'` (https://damien.pobel.fr/tag/lecteur-d'%C3%A9cran/) that previously worked fine.

### Level of change

- Bug fix
- Added functionality

unsure if it's a bug or a feature to be honest but given the comment in the source about Windows not accepting a quote, I tend to think it's a bug fix. (note: the comment suggests it's possible to override the regexp, but I haven't found a way to do it)

---

For **Added functionality** and **API changes** make sure the documentation has been updated accordingly.
