### PR TITLE
fix: Error creating permalinks with `:date`

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -103,5 +103,7 @@ function formatDate(date, format, locale) {
 }
 
 export function dateFormatter(format, locale) {
-  return (date) => formatDate(date, format, locale)
+  return function formatDateFn(date) {
+    return formatDate(date, format, locale)
+  }
 }

--- a/src/date.js
+++ b/src/date.js
@@ -82,24 +82,26 @@ const dateTokens = {
 
 const dateTokenKeys = Object.keys(dateTokens)
 
-export function dateFormatter(format, locale) {
-  return function formatDate(date) {
-    const result = []
-    while (format.length) {
-      let token
-      for (const tokenKey of dateTokenKeys) {
-        const match = format.match(tokenKey)
-        if (match && match.index === 0) {
-          token = match[0]
-          break
-        }
+function formatDate(date, format, locale) {
+  const result = []
+  while (format.length) {
+    let token
+    for (const tokenKey of dateTokenKeys) {
+      const match = format.match(tokenKey)
+      if (match && match.index === 0) {
+        token = match[0]
+        break
       }
-      const mappable = !!token
-      if (!token) token = format.slice(0, 1)
-      format = format.slice(token.length)
-      if (mappable) token = dateTokens[token](date, locale)
-      result.push(token)
     }
-    return result.join('')
+    const mappable = !!token
+    if (!token) token = format.slice(0, 1)
+    format = format.slice(token.length)
+    if (mappable) token = dateTokens[token](date, locale)
+    result.push(token)
   }
+  return result.join('')
+}
+
+export function dateFormatter(format, locale) {
+  return (date) => formatDate(date, format, locale)
 }

--- a/test/fixtures/linkset-custom-date/expected/bar/2024/11/bar-two/index.html
+++ b/test/fixtures/linkset-custom-date/expected/bar/2024/11/bar-two/index.html
@@ -1,0 +1,1 @@
+i should be at bar/2024/11/bar

--- a/test/fixtures/linkset-custom-date/src/bar2.html
+++ b/test/fixtures/linkset-custom-date/src/bar2.html
@@ -1,0 +1,6 @@
+---
+title: Bar Two
+bar: 21
+date: 2024-11-01
+---
+i should be at bar/2024/11/bar


### PR DESCRIPTION
### What has changed?

The date formatting function has been refactored.

The function should not return another function in this case because the parameters are only passed down once. By changing the scope of the function and passing the parameters independently, the error disappears.

### Level of change

- Bug fix

Fix: #143