### PR TITLE
fix: replace NUL in pattern with period

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,8 @@ const replace = ({ pattern, ...options }, data) => {
   const ret = {}
 
   for (let i = 0, key; (key = keys[i++]); ) {
-    const keypath = key.replace(/\0/g, '.')
+    // eslint-disable-next-line no-control-regex
+    const keypath = key.replace(/\x00/g, '.')
     const val = get(data, keypath)
     const isOptional = remapped.match(`${key}\\?`)
     if (!val || (Array.isArray(val) && val.length === 0)) {


### PR DESCRIPTION
### What has changed?

There's a bug where periods in paths aren't correctly handled, leaving a NUL character.

This required an ESLint single-line rule disable, which might not be desirable.

### Level of change

- Bug fix